### PR TITLE
Issue #2503569 by Pol: [symfony-integration] Support services.yml (follow-up)

### DIFF
--- a/modules/service_container_symfony/lib/Drupal/service_container_symfony/Tests/ServiceContainerSymfonyTest.php
+++ b/modules/service_container_symfony/lib/Drupal/service_container_symfony/Tests/ServiceContainerSymfonyTest.php
@@ -35,6 +35,8 @@ class ServiceContainerSymfonyTest extends ServiceContainerIntegrationTestBase {
    */
   public function testInit() {
     $this->assertTrue(\Drupal::hasService('testservicecontainersymfonyyolo'));
+    $this->assertFalse(\Drupal::hasService('TestServiceContainerSymfonyYolo'));
+    $this->assertFalse(\Drupal::hasService('testservicecontainersymfonyyolo1'));
   }
 
 }

--- a/modules/service_container_symfony/lib/Drupal/service_container_symfony/Tests/ServiceContainerSymfonyTest.php
+++ b/modules/service_container_symfony/lib/Drupal/service_container_symfony/Tests/ServiceContainerSymfonyTest.php
@@ -34,9 +34,8 @@ class ServiceContainerSymfonyTest extends ServiceContainerIntegrationTestBase {
    * Tests some basic
    */
   public function testInit() {
-    $this->assertTrue(\Drupal::hasService('testservicecontainersymfonyyolo'));
-    $this->assertFalse(\Drupal::hasService('TestServiceContainerSymfonyYolo'));
-    $this->assertFalse(\Drupal::hasService('testservicecontainersymfonyyolo1'));
+    $this->assertTrue(\Drupal::hasService('test_service_container_symfony_yolo'));
+    $this->assertFalse(\Drupal::hasService('test_service_container_symfony_yolo1'));
   }
 
 }

--- a/modules/service_container_symfony/lib/Drupal/service_container_symfony/Tests/ServiceContainerSymfonyTest.php
+++ b/modules/service_container_symfony/lib/Drupal/service_container_symfony/Tests/ServiceContainerSymfonyTest.php
@@ -34,8 +34,7 @@ class ServiceContainerSymfonyTest extends ServiceContainerIntegrationTestBase {
    * Tests some basic
    */
   public function testInit() {
-    $this->assertTrue(\Drupal::hasService('test_service_container_symfony_yolo'));
-    $this->assertFalse(\Drupal::hasService('test_service_container_symfony_yolo1'));
+    $this->assertTrue(\Drupal::hasService('testservicecontainersymfonyyolo'));
   }
 
 }

--- a/modules/service_container_symfony/src/ServiceContainer/ServiceProvider/ServiceContainerSymfonyServiceProvider.php
+++ b/modules/service_container_symfony/src/ServiceContainer/ServiceProvider/ServiceContainerSymfonyServiceProvider.php
@@ -27,8 +27,8 @@ class ServiceContainerSymfonyServiceProvider implements ServiceProviderInterface
   public function getContainerDefinition() {
     FileCacheFactory::setConfiguration(['default' => ['class' => '\Drupal\Component\FileCache\NullFileCache']]);
     $modules = module_list();
-    $container = new ContainerBuilder();
-    $yaml_loader = new YamlFileLoader($container);
+    $container_builder = new ContainerBuilder();
+    $yaml_loader = new YamlFileLoader($container_builder);
 
     foreach ($modules as $module) {
       $filename = drupal_get_filename('module', $module);
@@ -38,7 +38,8 @@ class ServiceContainerSymfonyServiceProvider implements ServiceProviderInterface
       }
     }
 
-    $dumper = new PhpArrayDumper($container);
+    $container_builder->compile();
+    $dumper = new PhpArrayDumper($container_builder);
     return $dumper->getArray();
   }
 

--- a/modules/service_container_symfony/tests/modules/test_service_container_symfony/src/TestServiceContainerSymfonyYolo.php
+++ b/modules/service_container_symfony/tests/modules/test_service_container_symfony/src/TestServiceContainerSymfonyYolo.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Drupal\test_service_container_symfony;
+
+class TestServiceContainerSymfonyYolo {
+
+}

--- a/modules/service_container_symfony/tests/modules/test_service_container_symfony/src/test_service_container_symfony_yolo.php
+++ b/modules/service_container_symfony/tests/modules/test_service_container_symfony/src/test_service_container_symfony_yolo.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace \Drupal\test_service_container_symfony\test_service_container_symfony_yolo;
-
-class test_service_container_symfony_yolo {
-
-
-
-}

--- a/modules/service_container_symfony/tests/modules/test_service_container_symfony/test_service_container_symfony.services.yml
+++ b/modules/service_container_symfony/tests/modules/test_service_container_symfony/test_service_container_symfony.services.yml
@@ -1,3 +1,3 @@
 services:
-  test_service_container_symfony_yolo:
-    class: Drupal\test_service_container_symfony\test_service_container_symfony_yolo
+  TestServiceContainerSymfonyYolo:
+    class: Drupal\test_service_container_symfony\TestServiceContainerSymfonyYolo

--- a/modules/service_container_symfony/tests/modules/test_service_container_symfony/test_service_container_symfony.services.yml
+++ b/modules/service_container_symfony/tests/modules/test_service_container_symfony/test_service_container_symfony.services.yml
@@ -1,3 +1,3 @@
 services:
-  testservicecontainersymfonyyolo:
+  test_service_container_symfony_yolo:
     class: Drupal\test_service_container_symfony\TestServiceContainerSymfonyYolo

--- a/modules/service_container_symfony/tests/modules/test_service_container_symfony/test_service_container_symfony.services.yml
+++ b/modules/service_container_symfony/tests/modules/test_service_container_symfony/test_service_container_symfony.services.yml
@@ -1,3 +1,3 @@
 services:
-  TestServiceContainerSymfonyYolo:
+  testservicecontainersymfonyyolo:
     class: Drupal\test_service_container_symfony\TestServiceContainerSymfonyYolo


### PR DESCRIPTION
Ticket: https://www.drupal.org/node/2503569

While service_container should also work without Symfony by design, there has been interest expressed to use services.yml also here.

This is just the basic integration, no added compiler passes, yet.
