### PR TITLE
Fix D8 Plugins construction.

### DIFF
--- a/src/Plugin/ContainerAwarePluginManager.php
+++ b/src/Plugin/ContainerAwarePluginManager.php
@@ -63,6 +63,7 @@ class ContainerAwarePluginManager extends ContainerAware implements PluginManage
       'arguments' => array(),
     );
 
+    array_unshift($plugin_definition['arguments'], $this->getDefinition($plugin_id));
     array_unshift($plugin_definition['arguments'], $plugin_id);
     array_unshift($plugin_definition['arguments'], $configuration);
 

--- a/src/Plugin/ContainerAwarePluginManager.php
+++ b/src/Plugin/ContainerAwarePluginManager.php
@@ -58,12 +58,12 @@ class ContainerAwarePluginManager extends ContainerAware implements PluginManage
    * {@inheritdoc}
    */
   public function createInstance($plugin_id, array $configuration = array()) {
-    $plugin_definition = $this->getDefinition($plugin_id);
+    $plugin_definition_copy = $plugin_definition = $this->getDefinition($plugin_id);
     $plugin_definition += array(
       'arguments' => array(),
     );
 
-    array_unshift($plugin_definition['arguments'], $this->getDefinition($plugin_id));
+    array_unshift($plugin_definition['arguments'], $plugin_definition_copy);
     array_unshift($plugin_definition['arguments'], $plugin_id);
     array_unshift($plugin_definition['arguments'], $configuration);
 

--- a/src/ServiceContainer/ServiceProvider/ServiceContainerServiceProvider.php
+++ b/src/ServiceContainer/ServiceProvider/ServiceContainerServiceProvider.php
@@ -219,14 +219,6 @@ class ServiceContainerServiceProvider implements ServiceProviderInterface {
         $discovery = new $discovery_class($tag['plugin_manager_definition']);
         $definitions = $discovery->getDefinitions();
         foreach ($definitions as $key => $definition) {
-          // Always pass the definition as the first argument.
-          $definition += array(
-            'arguments' => array(),
-          );
-          // array_unshift() internally uses a reference, therefore creates an
-          // endless recursion. Use a copy to prevent that.
-          $definition_copy = $definition;
-          array_unshift($definition['arguments'], $definition_copy);
           $container_definition['services'][$tag['prefix'] . $key] = $definition + array('public' => FALSE);
         }
       }


### PR DESCRIPTION
Make sure that $configuration, $plugin_id and $plugin_definition are passed to a plugin.
