### PR TITLE
Issue #2522032 by das-peter: AnnotatedClassDiscovery::getDefinitions(…

### DIFF
--- a/modules/providers/service_container_annotation_discovery/src/Plugin/Discovery/AnnotatedClassDiscovery.php
+++ b/modules/providers/service_container_annotation_discovery/src/Plugin/Discovery/AnnotatedClassDiscovery.php
@@ -125,8 +125,8 @@ class AnnotatedClassDiscovery implements DiscoveryInterface {
           foreach ($iterator as $fileinfo) {
             if ($fileinfo->getExtension() == 'php') {
               $sub_path = $iterator->getSubIterator()->getSubPath();
-              $sub_path = $sub_path ? str_replace(DIRECTORY_SEPARATOR, '\\', $sub_path) . '\\' : '';
-              $class = $namespace . '\\' . str_replace(DIRECTORY_SEPARATOR, '\\', $this->pluginManagerDefinition['directory']) . '\\' . $sub_path . $fileinfo->getBasename('.php');
+              $sub_path = $sub_path ? str_replace('/', '\\', $sub_path) . '\\' : '';
+              $class = $namespace . '\\' . str_replace('/', '\\', $this->pluginManagerDefinition['directory']) . '\\' . $sub_path . $fileinfo->getBasename('.php');
 
               // The filename is already known, so there is no need to find the
               // file. However, StaticReflectionParser needs a finder, so use a


### PR DESCRIPTION
See https://www.drupal.org/node/2522032

**Problem/Motivation**

Currently AnnotatedClassDiscovery::getDefinitions() uses DIRECTORY_SEPARATOR to replace / chars in class names.
But DIRECTORY_SEPARATOR is OS dependent and on windows it would replace \ with \ - leaving possible / untouched.
This leads to fatal error when trying to create a new class with the returned class name.

**Proposed resolution**

Simply use / for search and replace to ensure the namespace part only uses backslashes.

**Remaining tasks**

Reviews neede.
