### PR TITLE
Defined plugins may now have a required interface.

### DIFF
--- a/src/Plugin/ContainerAwarePluginManager.php
+++ b/src/Plugin/ContainerAwarePluginManager.php
@@ -22,8 +22,9 @@ class ContainerAwarePluginManager extends ContainerAware implements PluginManage
    * @param string $service_prefix
    *   The service prefix used to get the plugin instances from the container.
    */
-  public function __construct($service_prefix) {
+  public function __construct($service_prefix, $plugin_manager = array()) {
     $this->servicePrefix = $service_prefix;
+    $this->pluginManager = $plugin_manager;
   }
 
   /**
@@ -60,7 +61,8 @@ class ContainerAwarePluginManager extends ContainerAware implements PluginManage
    */
   public function createInstance($plugin_id, array $configuration = array()) {
     $plugin_definition_copy = $plugin_definition = $this->getDefinition($plugin_id);
-    $plugin_class = static::getPluginClass($plugin_id, $plugin_definition);
+    $plugin_interface = isset($this->pluginManager['interface']) ? $this->pluginManager['interface'] : NULL;
+    $plugin_class = static::getPluginClass($plugin_id, $plugin_definition, $plugin_interface);
 
     // If the plugin provides a factory method, pass the container to it.
     if (is_subclass_of($plugin_class, 'Drupal\Core\Plugin\ContainerFactoryPluginInterface')) {
@@ -121,7 +123,7 @@ class ContainerAwarePluginManager extends ContainerAware implements PluginManage
     }
 
     if ($required_interface && !is_subclass_of($plugin_definition['class'], $required_interface)) {
-      throw new PluginException(sprintf('Plugin "%s" (%s) in %s should implement interface %s.', $plugin_id, $plugin_definition['class'], $plugin_definition['provider'], $required_interface));
+      throw new PluginException(sprintf('Plugin "%s" (%s) should implement interface %s.', $plugin_id, $plugin_definition['class'], $required_interface));
     }
 
     return $class;

--- a/src/Plugin/ContainerAwarePluginManager.php
+++ b/src/Plugin/ContainerAwarePluginManager.php
@@ -17,6 +17,14 @@ use Drupal\service_container\DependencyInjection\ContainerAware;
 class ContainerAwarePluginManager extends ContainerAware implements PluginManagerInterface {
 
   /**
+   * The plugin manager definition.
+   *
+   * @var array
+   *   The plugin manager definition.
+   */
+  private $pluginManager = array();
+
+  /**
    * Constructs a ContainerAwarePluginManager object.
    *
    * @param string $service_prefix
@@ -60,7 +68,10 @@ class ContainerAwarePluginManager extends ContainerAware implements PluginManage
    * {@inheritdoc}
    */
   public function createInstance($plugin_id, array $configuration = array()) {
-    $plugin_definition_copy = $plugin_definition = $this->getDefinition($plugin_id);
+    $plugin_definition = $this->getDefinition($plugin_id);
+    $plugin_definition['provider'] = isset($this->pluginManager['owner']) ? $this->pluginManager['owner'] : NULL;
+    $plugin_definition_copy = $plugin_definition;
+
     $plugin_interface = isset($this->pluginManager['interface']) ? $this->pluginManager['interface'] : NULL;
     $plugin_class = static::getPluginClass($plugin_id, $plugin_definition, $plugin_interface);
 
@@ -123,7 +134,7 @@ class ContainerAwarePluginManager extends ContainerAware implements PluginManage
     }
 
     if ($required_interface && !is_subclass_of($plugin_definition['class'], $required_interface)) {
-      throw new PluginException(sprintf('Plugin "%s" (%s) should implement interface %s.', $plugin_id, $plugin_definition['class'], $required_interface));
+      throw new PluginException(sprintf('Plugin "%s" (%s) in %s must implement interface %s.', $plugin_id, $class, $plugin_definition['provider'], $required_interface));
     }
 
     return $class;

--- a/src/ServiceContainer/ServiceProvider/ServiceContainerServiceProvider.php
+++ b/src/ServiceContainer/ServiceProvider/ServiceContainerServiceProvider.php
@@ -352,7 +352,7 @@ class ServiceContainerServiceProvider implements ServiceProviderInterface {
     $prefix = "$name.internal.";
     return array(
       'class' => '\Drupal\service_container\Plugin\ContainerAwarePluginManager',
-      'arguments' => array($prefix),
+      'arguments' => array($prefix, $plugin_manager),
       'calls' => array(
         array('setContainer', array('@service_container')),
       ),


### PR DESCRIPTION
module.services.yml before:

```
parameters:
  annotated_plugins_auto_discovery.openlayers:
    - { owner: 'openlayers', type: 'Component', directory: 'Plugin/Component', class: 'Drupal\openlayers\Component\Annotation\OpenlayersPlugin'}
```

module.services.yml after:

```
parameters:
  annotated_plugins_auto_discovery.openlayers:
    - { owner: 'openlayers', type: 'Component', directory: 'Plugin/Component', class: 'Drupal\openlayers\Component\Annotation\OpenlayersPlugin', interface: 'Drupal\openlayers\Type\ComponentInterface'}
```
