### PR TITLE
Cast variable to array

### DIFF
--- a/lib/ServiceContainer.php
+++ b/lib/ServiceContainer.php
@@ -58,7 +58,7 @@ class ServiceContainer extends Drupal {
    *   The arguments to pass.
    */
   protected static function dispatchStaticEvent($event, $arguments) {
-    $event_listeners = static::$container->getParameter('service_container.static_event_listeners');
+    $event_listeners = (array) static::$container->getParameter('service_container.static_event_listeners');
     foreach ($event_listeners as $class) {
       $function = $class . '::' . $event;
       if (is_callable($function)) {


### PR DESCRIPTION
To avoid warnings when flushing caches with Drush.

```
pol@x230 ~/d/s/d/s/a/modules> drush cc all
Invalid argument supplied for foreach() ServiceContainer.php:62                    [warning]
'all' cache was cleared.                                                                                     [success]
pol@x230 ~/d/s/d/s/a/modules>
```
